### PR TITLE
Switch action to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: "The working directory to run the Dart analyzer in (defaults to `./`)."
     default: ./
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "hexagon"

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
   using: "node16"
   main: "dist/index.js"
 branding:
-  icon: "hexagon"
+  icon: "search"
   color: "gray-dark"


### PR DESCRIPTION
* node12 is deprecated
* I also switched the action icon since the one specified doesn't exist and default to a "play" icon 